### PR TITLE
feat(core): Add 'M' extension for multiplication and division

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It is written in **C**.
   - **Control Transfer**: `LUI`, `AUIPC`, `JAL`, `JALR`, `BEQ`, `BNE`, `BLT`, `BGE`, `BLTU`, `BGEU`
   - **Load and Store**: `LB`, `LH`, `LW`, `LBU`, `LHU`, `SB`, `SH`, `SW`
   - **System**: `ECALL`, `EBREAK`, `FENCE`
+  - **Multiplication and Division**: `MUL`, `MULH`, `MULHU`, `MULHSU`, `DIV`, `DIVU`, `REM`, `REMU`
 
 - **CPU and Memory Emulation**  
   Provides basic emulation of registers and memory.

--- a/program.s
+++ b/program.s
@@ -35,6 +35,18 @@ _start:
   sll   x4, x1, x2       # x4 = x1 << x2
   slt   x10, x1, x3      # x10 = 1 (signed comparison)
   sltu  x11, x1, x3      # x11 = 0 (unsigned comparison)
+  
+
+
+  # --- M-Extension: Multiplication ---
+  addi x5, x0, 8
+  addi x6, x0, 7
+  mul  x7, x5, x6  # x7 = 8 * 7 = 56
+
+  # --- M-Extension: Division ---
+  addi x8, x0, 100
+  addi x9, x0, 10
+  div  x10, x8, x9 # x10 = 100 / 10 = 10
 
   # --- I-Type: Shift Instructions ---
   lui   x20, 0x08000      # Load 0x80000 into the upper 20 bits of x20

--- a/src/instr.c
+++ b/src/instr.c
@@ -96,6 +96,64 @@ static void r_type_exec(struct cpu *c, const Instruction *instr)
 	u32 rs1 = instr->rs1;
 	u32 rs2 = instr->rs2;
 
+	if (instr->funct7 == 0x01) {
+		s64 val1 = (s64)(s32)c->registers[rs1];
+		s64 val2 = (s64)(s32)c->registers[rs2];
+		u64 u_val1 = (u64)c->registers[rs1];
+		u64 u_val2 = (u64)c->registers[rs2];
+		switch (instr->funct3) {
+		case 0x0: //MUL
+			c->registers[rd] = (u32)(val1 * val2);
+			break;
+		case 0x1: // MULH
+			c->registers[rd] = (u32)((val1 * val2) >> 32);
+			break;
+		case 0x2: // MULHSU
+			c->registers[rd] = (u32)(val1 * (s64)(u_val2) >> 32);
+			break;
+		case 0x3: // MULHU
+			c->registers[rd] = (u32)((u_val1 * u_val2) >> 32);
+			break;
+		case 0x4: // DIV
+			if (c->registers[rs2] == 0) {
+				c->registers[rd] =
+					0xFFFFFFFF; // Division by zero gives all 1s
+			} else {
+				c->registers[rd] =
+					(u32)((s32)c->registers[rs1] /
+					      (s32)c->registers[rs2]);
+			}
+			break;
+		case 0x5: // DIVU
+			if (c->registers[rs2] == 0) {
+				c->registers[rd] = 0xFFFFFFFF;
+			} else {
+				c->registers[rd] =
+					c->registers[rs1] / c->registers[rs2];
+			}
+			break;
+		case 0x6: // REM : signed reminder
+			if (c->registers[rs2] == 0) {
+				c->registers[rd] =
+					c->registers[rs1]; // reminder
+			} else {
+				c->registers[rd] =
+					(u32)((s32)c->registers[rs1] %
+					      (s32)c->registers[rs2]);
+			}
+			break;
+		case 0x7: // REMU : unsigned reminder
+			if (c->registers[rs2] == 0) {
+				c->registers[rd] = c->registers[rs1];
+			} else {
+				c->registers[rd] =
+					c->registers[rs1] % c->registers[rs2];
+			}
+			break;
+		}
+		return;
+	}
+
 	switch (instr->funct3) {
 	case 0x0: // ADD or SUB
 		if (instr->funct7 == 0x00) { // ADD

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -404,3 +404,29 @@ TEST_F(RV32ITest, SystemInstructions)
 	EXPECT_EQ(cpu->pc, 0); // PC should point to the ebreak instruction
 	EXPECT_EQ(cpu->state, CPU_STATE_HALTED);
 }
+
+TEST_F(RV32ITest, MUL)
+{
+	std::vector<uint32_t> program = {
+		0x00500093, // addi x1, x0, 5
+		0x00A00113, // addi x2, x0, 10
+		0x022081B3, // mul x3, x1, x2 (5 * 10 = 50)
+	};
+	load_program(program);
+	run_program(program.size());
+
+	EXPECT_EQ(cpu->registers[3], 50);
+}
+
+TEST_F(RV32ITest, DIV)
+{
+	std::vector<uint32_t> program = {
+		0x06400093, // addi x1, x0, 100
+		0x00A00113, // addi x2, x0, 10
+		0x0220C1B3, // div x3, x1, x2 (100 / 10 = 10)
+	};
+	load_program(program);
+	run_program(program.size());
+
+	EXPECT_EQ(cpu->registers[3], 10);
+}


### PR DESCRIPTION
Implements the full RV32IM instruction set by adding support for all multiplication and division operations (MUL, DIV, REM and their variants). The implementation uses host 64-bit arithmetic for correctness and performance.